### PR TITLE
Change EOF check in background_tail to check for empty string instead of None

### DIFF
--- a/sonic-pi-tool.py
+++ b/sonic-pi-tool.py
@@ -155,7 +155,7 @@ class Installation:
                 line = ''
                 while True:
                     tmp = f.readline()
-                    if tmp is not None:
+                    if tmp:
                         line += tmp
                         if line.endswith('\n'):
                             func(line)


### PR DESCRIPTION
According to the Python documentation, `io.TextIOBase.readline` returns an empty string, not `None`, when it reaches EOF. The `readline` method is used in `background_tail` (called when doing `start-server`) and the return value is checked to determine whether to process input or sleep. It currently checks only for `None` instead of an empty string and in my case this meant that there was no idling in the loop (as it did not sleep) and it then ate all of my CPU and spun up my fans.

This PR changes the conditional to just check for a truthy value to determine whether to process input or sleep. This fixed the issue of the loop not idling and eating all of my CPU time.

Let me know if you need anything else (changes, more details, etc). Thank you for making this awesome tool!

Python documentation reference: https://docs.python.org/3/library/io.html#io.TextIOBase.readline